### PR TITLE
Add foundational planning documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,12 @@
-Keep this file up to date with information the agent needs to know.
+# Agent Instructions
+
+Always consult the documentation in this repository before making changes.
+
+## Required Reading
+- `README.md` – overview and orientation.
+- `docs/PLAN.md` – delivery phases and milestones.
+- `docs/REQUIREMENTS.md` – functional and non-functional expectations.
+- `docs/DESIGN.md` – architecture and module breakdown.
+- `docs/TASKS.md` – current backlog and priorities.
+
+Keep these files up to date whenever you introduce new capabilities or adjust scope. Document open questions or follow-up work in the appropriate file.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ This repository documents the plan for building a local-first coding assistant t
 - [`docs/DESIGN.md`](docs/DESIGN.md) – module-level architecture and integration notes.
 - [`docs/TASKS.md`](docs/TASKS.md) – active and upcoming tasks.
 
+## Key Technology Decisions
+- **Sandboxing**: Bubblewrap (`bwrap`) provides jailed shell execution for all sessions.
+- **Runtime**: All Python services target version 3.9+ to maximize compatibility.
+- **Storage**: SQLite backs early metadata needs (sessions, tasks, analytics) before migrating to heavier stores.
+- **LLM Integration**: OpenAI-based agents coordinate coding assistance across CLI and web experiences.
+
 ## Contributing Guidance
 - Follow any instructions in `AGENTS.md` files before making changes.
 - Prefer incremental updates: keep documentation accurate as you implement functionality.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Local Coding Agent Workspace
+
+This repository documents the plan for building a local-first coding assistant that can operate via both a command-line interface and a web application. The assistant will coordinate with a jailed shell for workspace execution, support session tracking for multiple users, and capture token-usage analytics.
+
+## Getting Started
+1. Review the **Plan**, **Requirements**, **Design**, and **Task Board** documents in the [`docs/`](docs/) directory before working on the project.
+2. Update the relevant documentation whenever you add features or make architectural decisions.
+3. Keep this top-level README aligned with the current system direction.
+
+## Key Documents
+- [`docs/PLAN.md`](docs/PLAN.md) – delivery roadmap and milestones.
+- [`docs/REQUIREMENTS.md`](docs/REQUIREMENTS.md) – functional and non-functional expectations.
+- [`docs/DESIGN.md`](docs/DESIGN.md) – module-level architecture and integration notes.
+- [`docs/TASKS.md`](docs/TASKS.md) – active and upcoming tasks.
+
+## Contributing Guidance
+- Follow any instructions in `AGENTS.md` files before making changes.
+- Prefer incremental updates: keep documentation accurate as you implement functionality.
+- Capture open questions or assumptions in the documentation to help future contributors.
+
+## Current Status
+The project is in the planning phase. Implementation work should begin after the initial requirements and design documents are reviewed and approved.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,62 @@
+# System Design
+
+This document describes the major components required to deliver the local coding agent platform. Update the module breakdown as the architecture evolves.
+
+## High-Level Architecture
+The system is composed of several services orchestrated around session management:
+
+- **Gateway Layer**: REST/GraphQL APIs supporting both CLI and web clients, plus WebSocket channels for streaming shell output.
+- **Agent Orchestrator**: Coordinates task assignment, invokes the jailed shell, and manages tool availability per agent persona.
+- **Workspace Service**: Prepares repo copies, enforces filesystem quotas, and snapshots state for auditing.
+- **Analytics Pipeline**: Captures token usage, session metrics, and operational telemetry for reporting and alerting.
+- **Data Stores**: Configuration database (PostgreSQL or equivalent), object storage for workspace snapshots, and time-series store for metrics.
+
+## Module Breakdown
+
+### 1. CLI Interface
+- **Responsibilities**: Authenticate users, render command menus, stream shell output, and surface task details.
+- **Key Interactions**: Calls Gateway APIs, subscribes to WebSocket channels, and posts task status updates.
+- **Implementation Notes**: Favor a plugin architecture for future tooling; support offline caching of task metadata.
+- **Open Questions**: Should the CLI embed an editor mode or rely on external editors synced to the workspace?
+
+### 2. Web Application
+- **Responsibilities**: Provide interactive dashboards for sessions, tasks, and analytics while maintaining parity with CLI capabilities.
+- **Key Interactions**: Uses Gateway APIs and WebSocket endpoints; renders charts from analytics summaries.
+- **Implementation Notes**: Consider a component library that supports dark mode and accessibility standards.
+- **Open Questions**: Determine preferred front-end stack (React, Svelte, etc.) and hosting model.
+
+### 3. Session Manager
+- **Responsibilities**: Maintain session lifecycle, allocate jailed shell instances, and enforce concurrency policies.
+- **Key Interactions**: Communicates with Workspace Service for repo preparation and with Analytics Pipeline for event emission.
+- **Implementation Notes**: Use an event-driven architecture (message queue) to decouple shell provisioning from user requests.
+- **Open Questions**: How should long-running background tasks (e.g., tests) be tracked within a session?
+
+### 4. Jailed Shell Service
+- **Responsibilities**: Provide isolated execution environments with network, filesystem, and process limits.
+- **Key Interactions**: Receives command requests from the Session Manager and streams output to clients via Gateway.
+- **Implementation Notes**: Evaluate container-based isolation with per-session images and layered caching.
+- **Open Questions**: What auditing mechanism is required to track file diffs and commands executed?
+
+### 5. Task Coordination Service
+- **Responsibilities**: Store task metadata, track ownership, log progress updates, and integrate with PR tooling.
+- **Key Interactions**: Syncs with `docs/TASKS.md` (initial source of truth) and exposes CRUD operations to clients.
+- **Implementation Notes**: Start with markdown parsing; evolve to a database once collaborative edits become frequent.
+- **Open Questions**: When should we automate task assignment based on agent workload or expertise?
+
+### 6. Analytics & Reporting
+- **Responsibilities**: Aggregate token consumption, session duration, task completion metrics, and cost estimates.
+- **Key Interactions**: Ingests events from Gateway, Session Manager, and Task Coordination services; exposes dashboards via the web app.
+- **Implementation Notes**: Choose a telemetry stack (OpenTelemetry, Prometheus) that integrates with both CLI and web clients.
+- **Open Questions**: What cadence should usage reports be delivered, and who consumes them?
+
+## Cross-Cutting Concerns
+- **Authentication & Authorization**: Centralize identity enforcement at the Gateway and propagate scoped tokens to downstream services.
+- **Configuration Management**: Maintain environment-specific settings in version-controlled templates with secrets stored externally.
+- **Logging & Monitoring**: Standardize structured logging formats and ensure trace IDs propagate across components.
+- **Testing Strategy**: Provide unit tests per module, integration tests for key workflows (session creation, shell command execution), and end-to-end tests for CLI and web flows.
+- **Documentation**: Keep module documentation synchronized with implementation; link code references back to this design.
+
+## Future Enhancements
+- Model-based policy engine to limit tool usage by role or compliance category.
+- AI-assisted code review workflows integrated with the task coordination service.
+- Extension marketplace for third-party tools vetted through sandboxed execution.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -6,10 +6,10 @@ This document describes the major components required to deliver the local codin
 The system is composed of several services orchestrated around session management:
 
 - **Gateway Layer**: REST/GraphQL APIs supporting both CLI and web clients, plus WebSocket channels for streaming shell output.
-- **Agent Orchestrator**: Coordinates task assignment, invokes the jailed shell, and manages tool availability per agent persona.
+- **Agent Orchestrator**: Coordinates task assignment, invokes the jailed shell, manages tool availability per agent persona, and brokers OpenAI-powered assistance flows.
 - **Workspace Service**: Prepares repo copies, enforces filesystem quotas, and snapshots state for auditing.
 - **Analytics Pipeline**: Captures token usage, session metrics, and operational telemetry for reporting and alerting.
-- **Data Stores**: Configuration database (PostgreSQL or equivalent), object storage for workspace snapshots, and time-series store for metrics.
+- **Data Stores**: SQLite for early metadata (sessions, tasks, analytics summaries), object storage for workspace snapshots, and a time-series store for metrics as scale increases.
 
 ## Module Breakdown
 
@@ -28,19 +28,19 @@ The system is composed of several services orchestrated around session managemen
 ### 3. Session Manager
 - **Responsibilities**: Maintain session lifecycle, allocate jailed shell instances, and enforce concurrency policies.
 - **Key Interactions**: Communicates with Workspace Service for repo preparation and with Analytics Pipeline for event emission.
-- **Implementation Notes**: Use an event-driven architecture (message queue) to decouple shell provisioning from user requests.
+- **Implementation Notes**: Use an event-driven architecture (message queue) to decouple shell provisioning from user requests and persist session metadata in SQLite.
 - **Open Questions**: How should long-running background tasks (e.g., tests) be tracked within a session?
 
 ### 4. Jailed Shell Service
 - **Responsibilities**: Provide isolated execution environments with network, filesystem, and process limits.
 - **Key Interactions**: Receives command requests from the Session Manager and streams output to clients via Gateway.
-- **Implementation Notes**: Evaluate container-based isolation with per-session images and layered caching.
+- **Implementation Notes**: Use Bubblewrap (`bwrap`) to create process-isolated sandboxes with predefined filesystem and network policies.
 - **Open Questions**: What auditing mechanism is required to track file diffs and commands executed?
 
 ### 5. Task Coordination Service
 - **Responsibilities**: Store task metadata, track ownership, log progress updates, and integrate with PR tooling.
 - **Key Interactions**: Syncs with `docs/TASKS.md` (initial source of truth) and exposes CRUD operations to clients.
-- **Implementation Notes**: Start with markdown parsing; evolve to a database once collaborative edits become frequent.
+- **Implementation Notes**: Start with markdown parsing backed by SQLite tables for richer queries; evolve to a larger database once collaborative edits become frequent.
 - **Open Questions**: When should we automate task assignment based on agent workload or expertise?
 
 ### 6. Analytics & Reporting
@@ -53,7 +53,8 @@ The system is composed of several services orchestrated around session managemen
 - **Authentication & Authorization**: Centralize identity enforcement at the Gateway and propagate scoped tokens to downstream services.
 - **Configuration Management**: Maintain environment-specific settings in version-controlled templates with secrets stored externally.
 - **Logging & Monitoring**: Standardize structured logging formats and ensure trace IDs propagate across components.
-- **Testing Strategy**: Provide unit tests per module, integration tests for key workflows (session creation, shell command execution), and end-to-end tests for CLI and web flows.
+- **Runtime Baseline**: Standardize on Python 3.9+ for backend services and tooling to simplify packaging and compatibility.
+- **Testing Strategy**: Provide extensive automated coverage—unit tests per module, integration tests for key workflows (session creation, shell command execution), and end-to-end tests for CLI and web flows—with gating in CI.
 - **Documentation**: Keep module documentation synchronized with implementation; link code references back to this design.
 
 ## Future Enhancements

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,6 +1,6 @@
 # Delivery Plan
 
-This plan outlines the staged delivery of the local coding agent platform. Each phase builds on the previous one and should conclude with updated documentation and demos where applicable.
+This plan outlines the staged delivery of the local coding agent platform. Each phase builds on the previous one and should conclude with updated documentation and demos where applicable. Core technology choices—Bubblewrap sandboxing, Python 3.9+ services, SQLite storage, and OpenAI-powered agents—remain constant unless new evidence demands change.
 
 ## Phase 0 – Planning (Current)
 - Draft foundational documents (plan, requirements, design, and task board).
@@ -8,22 +8,22 @@ This plan outlines the staged delivery of the local coding agent platform. Each 
 - Validate that the repository structure supports future automation and testing.
 
 ## Phase 1 – Core Infrastructure
-- Implement repository bootstrapping scripts to provision a jailed shell workspace per session.
-- Build a session manager that tracks user identity, active workspaces, and lifecycle events.
+- Implement repository bootstrapping scripts to provision a Bubblewrap (`bwrap`) jailed shell workspace per session.
+- Build a session manager that tracks user identity, active workspaces, and lifecycle events with a SQLite-backed metadata store.
 - Establish persistent storage for session metadata and token usage logs.
-- Provide smoke tests verifying shell sandbox creation, command execution, and teardown.
+- Provide smoke tests verifying shell sandbox creation, command execution, teardown, and Python 3.9 compatibility for CLI utilities.
 
 ## Phase 2 – CLI Agent Experience
 - Develop the CLI interface for interacting with the coding agent.
-- Integrate the CLI with session management and token accounting services.
+- Integrate the CLI with session management and token accounting services using OpenAI agents for assistance workflows.
 - Support task selection from the shared task board and progress reporting back to the task system.
-- Add instrumentation for command latency, error rates, and shell resource utilization.
+- Add instrumentation for command latency, error rates, and shell resource utilization, backed by automated test coverage.
 
 ## Phase 3 – Web Application Experience
 - Build a web front-end that mirrors CLI functionality with an emphasis on usability.
-- Expose APIs for session management, shell interactions, and task state updates.
+- Expose APIs for session management, shell interactions, and task state updates, validating Python 3.9+ compatibility for shared services.
 - Provide authentication and authorization layers to ensure isolated workspaces per user.
-- Implement real-time feedback (web sockets or polling) for shell output streaming.
+- Implement real-time feedback (web sockets or polling) for shell output streaming with automated regression tests.
 
 ## Phase 4 – Advanced Capabilities
 - Offer collaboration features such as shared sessions or task hand-offs.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,43 @@
+# Delivery Plan
+
+This plan outlines the staged delivery of the local coding agent platform. Each phase builds on the previous one and should conclude with updated documentation and demos where applicable.
+
+## Phase 0 – Planning (Current)
+- Draft foundational documents (plan, requirements, design, and task board).
+- Identify stakeholders, decision makers, and review cadence.
+- Validate that the repository structure supports future automation and testing.
+
+## Phase 1 – Core Infrastructure
+- Implement repository bootstrapping scripts to provision a jailed shell workspace per session.
+- Build a session manager that tracks user identity, active workspaces, and lifecycle events.
+- Establish persistent storage for session metadata and token usage logs.
+- Provide smoke tests verifying shell sandbox creation, command execution, and teardown.
+
+## Phase 2 – CLI Agent Experience
+- Develop the CLI interface for interacting with the coding agent.
+- Integrate the CLI with session management and token accounting services.
+- Support task selection from the shared task board and progress reporting back to the task system.
+- Add instrumentation for command latency, error rates, and shell resource utilization.
+
+## Phase 3 – Web Application Experience
+- Build a web front-end that mirrors CLI functionality with an emphasis on usability.
+- Expose APIs for session management, shell interactions, and task state updates.
+- Provide authentication and authorization layers to ensure isolated workspaces per user.
+- Implement real-time feedback (web sockets or polling) for shell output streaming.
+
+## Phase 4 – Advanced Capabilities
+- Offer collaboration features such as shared sessions or task hand-offs.
+- Introduce customizable agent personas with different tool-usage policies.
+- Expand analytics to include trend reporting, cost forecasting, and alerting on anomalous usage.
+- Harden the system with load tests, disaster-recovery drills, and security reviews.
+
+## Phase 5 – Operational Excellence
+- Automate deployment and environment updates for both CLI and web interfaces.
+- Establish SLOs/SLIs with monitoring dashboards and on-call runbooks.
+- Conduct regular documentation reviews to keep requirements, design, and task board current.
+- Plan for community contributions, coding standards, and extension mechanisms.
+
+## Review Cadence
+- End-of-phase review meetings with key stakeholders to approve progression.
+- Weekly backlog grooming using `docs/TASKS.md` to ensure priorities remain aligned.
+- Monthly analytics review to assess token consumption and infrastructure costs (once implemented).

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,0 +1,48 @@
+# System Requirements
+
+This document captures the initial requirements for the local CLI and web-based coding assistant. Revisit and expand these requirements as implementation progresses.
+
+## Functional Requirements
+1. **Jailed Shell Workspaces**
+   - Provision isolated shell environments per session with access to a dedicated workspace copy of the repository.
+   - Support command execution, file inspection, and modification within the sandbox while preventing host escape.
+   - Allow configurable resource limits (CPU, memory, disk) and runtime timeouts.
+
+2. **Session Management**
+   - Track sessions by user identity, creation timestamp, active workspace, and status.
+   - Support concurrent sessions for different users and serialize state for restoration after restarts.
+   - Provide lifecycle controls: create, pause, resume, archive, and delete.
+
+3. **CLI Interface**
+   - Enable authenticated users to start sessions, run commands, edit files, and request tasks.
+   - Display streamed shell output with clear prompts and error handling.
+   - Offer shortcuts for viewing documentation, task lists, and analytics summaries.
+
+4. **Web Application**
+   - Provide equivalent capabilities to the CLI through a responsive user interface.
+   - Support real-time shell output updates (web sockets preferred, fallback to polling).
+   - Include session dashboards, token-usage charts, and task progress indicators.
+
+5. **Task Coordination**
+   - Integrate with `docs/TASKS.md` (or successor system) to present available work and capture status updates.
+   - Allow agents to claim tasks, record notes, and mark completion with links to commits or PRs.
+
+6. **Token Usage Reporting**
+   - Record tokens consumed per session, per task, and per feature (CLI vs. web).
+   - Provide exportable summaries (CSV/JSON) and visualizations for trending.
+   - Trigger alerts when usage exceeds configurable thresholds.
+
+## Non-Functional Requirements
+1. **Security**: Ensure shell isolation, sanitize user input, and protect stored credentials.
+2. **Reliability**: Aim for 99% session uptime and graceful recovery from infrastructure failures.
+3. **Performance**: Shell command latency should remain under 2 seconds for 95% of operations.
+4. **Scalability**: Support at least 20 concurrent active sessions without resource contention.
+5. **Observability**: Capture structured logs, metrics, and traces across components.
+6. **Extensibility**: Architect modules with clear interfaces to enable future agent tooling integrations.
+7. **Compliance**: Retain token usage records according to organizational policy (default 90 days) and respect user privacy preferences.
+
+## Open Questions
+- What identity provider will back authentication for CLI and web clients?
+- Which sandboxing technology (containers, virtual machines, WASM) best balances security and performance?
+- How will tasks transition from markdown to a database-backed system if needed?
+- Are there budget constraints influencing infrastructure or token consumption limits?

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -7,6 +7,7 @@ This document captures the initial requirements for the local CLI and web-based 
    - Provision isolated shell environments per session with access to a dedicated workspace copy of the repository.
    - Support command execution, file inspection, and modification within the sandbox while preventing host escape.
    - Allow configurable resource limits (CPU, memory, disk) and runtime timeouts.
+   - Use Bubblewrap (`bwrap`) for sandbox enforcement and document default profiles.
 
 2. **Session Management**
    - Track sessions by user identity, creation timestamp, active workspace, and status.
@@ -32,6 +33,11 @@ This document captures the initial requirements for the local CLI and web-based 
    - Provide exportable summaries (CSV/JSON) and visualizations for trending.
    - Trigger alerts when usage exceeds configurable thresholds.
 
+7. **Agent Orchestration**
+   - Leverage OpenAI-powered agents for coding assistance across CLI and web clients.
+   - Provide configuration for model selection, safety filters, and per-session policy controls.
+   - Log prompts/responses with privacy safeguards to feed analytics and debugging workflows.
+
 ## Non-Functional Requirements
 1. **Security**: Ensure shell isolation, sanitize user input, and protect stored credentials.
 2. **Reliability**: Aim for 99% session uptime and graceful recovery from infrastructure failures.
@@ -40,9 +46,11 @@ This document captures the initial requirements for the local CLI and web-based 
 5. **Observability**: Capture structured logs, metrics, and traces across components.
 6. **Extensibility**: Architect modules with clear interfaces to enable future agent tooling integrations.
 7. **Compliance**: Retain token usage records according to organizational policy (default 90 days) and respect user privacy preferences.
+8. **Compatibility**: Ensure all services, tooling, and dependencies run on Python 3.9+.
+9. **Quality**: Maintain comprehensive automated test coverage (unit, integration, and end-to-end) with continuous enforcement in CI.
 
 ## Open Questions
 - What identity provider will back authentication for CLI and web clients?
-- Which sandboxing technology (containers, virtual machines, WASM) best balances security and performance?
 - How will tasks transition from markdown to a database-backed system if needed?
 - Are there budget constraints influencing infrastructure or token consumption limits?
+- What governance is required around OpenAI model usage (e.g., rate limits, data retention, fallback providers)?

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -10,14 +10,18 @@ This backlog highlights near-term priorities and longer-term initiatives. Update
 ## Active Tasks
 | ID | Title | Status | Priority | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| T-001 | Finalize requirements and design review | In Progress | P0 | Unassigned | Gather stakeholder feedback on `docs/REQUIREMENTS.md` and `docs/DESIGN.md`. |
-| T-002 | Define sandbox technology stack | Todo | P0 | Unassigned | Compare container, VM, and WASM-based approaches; document decision. |
+| T-001 | Finalize requirements and design review | Review | P0 | Unassigned | Updated docs with decisions on Bubblewrap, Python 3.9, SQLite, and OpenAI agents—await stakeholder sign-off. |
+| T-002 | Define sandbox technology stack | Done | P0 | Unassigned | Bubblewrap (`bwrap`) selected for jailed shell execution. |
 | T-003 | Draft session manager data model | Todo | P1 | Unassigned | Outline schema for sessions, users, and token usage events. |
 | T-004 | Outline CLI user journey | Todo | P1 | Unassigned | Create wireframes/flows for CLI interactions and error handling. |
 | T-005 | Outline web UI information architecture | Todo | P1 | Unassigned | Draft navigation, views, and component responsibilities. |
 | T-006 | Evaluate analytics tooling options | Todo | P2 | Unassigned | Assess metrics, logging, and visualization stack compatibility. |
 | T-007 | Establish contribution guidelines | Todo | P2 | Unassigned | Expand README with coding standards and review process once implementation begins. |
 | T-008 | Prototype token usage reporting schema | Todo | P2 | Unassigned | Define aggregation strategy for session and task level usage data. |
+| T-009 | Implement Bubblewrap sandbox provisioning | Todo | P0 | Unassigned | Build scripts/services to launch `bwrap` sandboxes with auditing hooks. |
+| T-010 | Stand up SQLite-backed session store | Todo | P1 | Unassigned | Model tables for sessions, token usage, and task links with migration tooling. |
+| T-011 | Integrate OpenAI agent orchestration | Todo | P1 | Unassigned | Wire agent orchestrator to OpenAI APIs with configurable policies and logging. |
+| T-012 | Establish automated testing baseline | Todo | P0 | Unassigned | Define CI workflows and minimum coverage thresholds across services. |
 
 ## Upcoming Ideas
 - Automate synchronization between markdown tasks and a future database-backed service.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,31 @@
+# Task Board
+
+This backlog highlights near-term priorities and longer-term initiatives. Update task status as work progresses and create new tasks for uncovered work.
+
+## Legend
+- **Status**: `Todo`, `In Progress`, `Blocked`, `Review`, `Done`
+- **Owner**: `Unassigned` unless a contributor has claimed it
+- **Priority**: `P0` (urgent) to `P3` (nice to have)
+
+## Active Tasks
+| ID | Title | Status | Priority | Owner | Notes |
+| --- | --- | --- | --- | --- | --- |
+| T-001 | Finalize requirements and design review | In Progress | P0 | Unassigned | Gather stakeholder feedback on `docs/REQUIREMENTS.md` and `docs/DESIGN.md`. |
+| T-002 | Define sandbox technology stack | Todo | P0 | Unassigned | Compare container, VM, and WASM-based approaches; document decision. |
+| T-003 | Draft session manager data model | Todo | P1 | Unassigned | Outline schema for sessions, users, and token usage events. |
+| T-004 | Outline CLI user journey | Todo | P1 | Unassigned | Create wireframes/flows for CLI interactions and error handling. |
+| T-005 | Outline web UI information architecture | Todo | P1 | Unassigned | Draft navigation, views, and component responsibilities. |
+| T-006 | Evaluate analytics tooling options | Todo | P2 | Unassigned | Assess metrics, logging, and visualization stack compatibility. |
+| T-007 | Establish contribution guidelines | Todo | P2 | Unassigned | Expand README with coding standards and review process once implementation begins. |
+| T-008 | Prototype token usage reporting schema | Todo | P2 | Unassigned | Define aggregation strategy for session and task level usage data. |
+
+## Upcoming Ideas
+- Automate synchronization between markdown tasks and a future database-backed service.
+- Investigate agent persona configuration and policy management.
+- Explore integration with external issue trackers for bidirectional updates.
+
+## How to Work on a Task
+1. Claim the task by updating the Owner and Status columns.
+2. Reference relevant requirements and design sections when planning implementation.
+3. Upon completion, link to the commit/PR and summarize results in the Notes column.
+4. If a task becomes blocked, add context in Notes and propose a follow-up task if necessary.


### PR DESCRIPTION
## Summary
- add a top-level README that orients contributors to the planning documents
- document delivery phases, requirements, design, and initial task backlog for the coding agent platform
- update agent instructions to require reviewing the new documentation set

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c9dd8669c8832aab9fe0e6d6c5f147